### PR TITLE
Add super admin password reset page

### DIFF
--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -9,6 +9,9 @@
     <h1>Usuarios Registrados</h1>
     
     <a href="/admin/add_user" class="add-user-button">➕ Añadir Usuario</a>
+    {% if current_user.usuario in ['sclavero', 'asanahuja'] %}
+    <a href="/admin/reset_passwords" class="add-user-button">🔑 Resetear Contraseñas</a>
+    {% endif %}
 
     <table border="1">
         <tr>

--- a/templates/reset_passwords.html
+++ b/templates/reset_passwords.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resetear Contraseñas</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <h1>Resetear Contraseñas de Usuarios</h1>
+
+    <table border="1">
+        <tr>
+            <th>Nombre</th>
+            <th>Usuario</th>
+            <th>Nueva Contraseña</th>
+        </tr>
+        {% for usuario in usuarios %}
+        <tr>
+            <td>{{ usuario.nombre }} {{ usuario.apellidos }}</td>
+            <td>{{ usuario.usuario }}</td>
+            <td>
+                <form method="POST" action="{{ url_for('reset_password', user_id=usuario._id) }}">
+                    <input type="password" name="new_password" required>
+                    <button type="submit">Resetear</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <br>
+    <a href="/admin/users">⬅️ Volver a la Gestión de Usuarios</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a decorator `super_admin_required` for extra admin checks
- add routes to list users and reset their passwords
- add link to the new page from the admin users page
- include a new template to reset passwords

## Testing
- `python -m py_compile app.py`
- `python -m py_compile generar_faqs.py procesar_pdfs.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc7f9cef883229621ac508275ec7a